### PR TITLE
Fix ArraySpeciesCreate to return a new Array when the given object is not an array

### DIFF
--- a/Source/JavaScriptCore/ChangeLog
+++ b/Source/JavaScriptCore/ChangeLog
@@ -1,3 +1,20 @@
+2018-05-09  Leo Balter  <leonardo.balter@gmail.com>
+
+        [JSC] Fix ArraySpeciesCreate to return a new Array when the given object is not an array
+        Error found in the following Test262 tests:
+
+        - test/built-ins/Array/prototype/slice/create-non-array-invalid-len.js
+        - test/built-ins/Array/prototype/slice/create-proxied-array-invalid-len.js
+        - test/built-ins/Array/prototype/splice/create-species-undef-invalid-len.js
+
+        The ArraySpeciesCreate should throw a RangeError with non-Array custom objects
+        presenting a length > 2**32-1
+        https://bugs.webkit.org/show_bug.cgi?id=185476
+
+        Reviewed by NOBODY (OOPS!).
+
+        * runtime/ArrayPrototype.cpp:
+
 2018-05-09  Srdjan Lazarevic  <srdjan.lazarevic@rt-rk.com>
 
         [MIPS] Optimize generated JIT code using r2

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -249,11 +249,8 @@ static ALWAYS_INLINE std::pair<SpeciesConstructResult, JSObject*> speciesConstru
         }
     } else {
         // If isArray is false, return ? ArrayCreate(length).
-        JSGlobalObject* globalObject = thisObject->globalObject();
-        JSValue newValue = constructArrayWithSizeQuirk(exec, nullptr, globalObject, jsNumber(length), exec->newTarget());
-        JSObject* newObject = newValue.toObject(exec);
         RETURN_IF_EXCEPTION(scope, exceptionResult());
-        return std::make_pair(SpeciesConstructResult::CreatedObject, newObject);
+        return std::make_pair(SpeciesConstructResult::FastPath, nullptr);
     }
 
     if (constructor.isUndefined())

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -247,8 +247,14 @@ static ALWAYS_INLINE std::pair<SpeciesConstructResult, JSObject*> speciesConstru
             if (constructor.isNull())
                 return std::make_pair(SpeciesConstructResult::FastPath, nullptr);;
         }
-    } else
+    } else {
+        // If isArray is false, return ? ArrayCreate(length).
+        JSGlobalObject* globalObject = thisObject->globalObject();
+        JSValue newValue = constructArrayWithSizeQuirk(exec, nullptr, globalObject, jsNumber(length), exec->newTarget());
+        JSObject* newObject = newValue.toObject(exec);
         RETURN_IF_EXCEPTION(scope, exceptionResult());
+        return std::make_pair(SpeciesConstructResult::CreatedObject, newObject);
+    }
 
     if (constructor.isUndefined())
         return std::make_pair(SpeciesConstructResult::FastPath, nullptr);

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -249,7 +249,6 @@ static ALWAYS_INLINE std::pair<SpeciesConstructResult, JSObject*> speciesConstru
         }
     } else {
         // If isArray is false, return ? ArrayCreate(length).
-        RETURN_IF_EXCEPTION(scope, exceptionResult());
         return std::make_pair(SpeciesConstructResult::FastPath, nullptr);
     }
 


### PR DESCRIPTION
Error found in the following Test262 tests:

- test/built-ins/Array/prototype/slice/create-non-array-invalid-len.js
- test/built-ins/Array/prototype/slice/create-proxied-array-invalid-len.js
- test/built-ins/Array/prototype/splice/create-species-undef-invalid-len.js